### PR TITLE
Fixed Import Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ aiohttp
 simple_pid
 aiortc
 mediapipe
+aiohttp_cors
+ujson


### PR DESCRIPTION
In my ubuntu 20.04, I had an import error, so I added missing libraries in the requirements.txt